### PR TITLE
htbuilder 0.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "htbuilder" %}
-{% set version = "0.6.1" %}
+{% set version = "0.6.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/htbuilder-{{ version }}.tar.gz
-  sha256: b7cafab8f27162a35f7ce15e387239c95d12c3d81fc38f91cad499e88cc0fcd8
+  sha256: 9979a4fb6e50ce732bf6f6bc0441039dcaa3a3fc70689d8f38f601ed8a1aeec0
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
htbuilder 0.6.2 :snowflake:

**Destination channel:** defaults

### Links

- [PKG-4424](https://anaconda.atlassian.net/browse/PKG-4424) 
- [Upstream repository](https://github.com/tvst/htbuilder/tree/v0.6.2)

### Explanation of changes:

- updated version # and sha


[PKG-4424]: https://anaconda.atlassian.net/browse/PKG-4424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ